### PR TITLE
Fix shebang... in another way

### DIFF
--- a/bin/mpath
+++ b/bin/mpath
@@ -1,4 +1,4 @@
-#!perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use 5.006;

--- a/dist.ini
+++ b/dist.ini
@@ -11,6 +11,7 @@ version = 0.19
 -remove = GatherDir
 [GatherDir]
 exclude_filename = cpanfile
+[SetScriptShebang]
 [CPANFile]
 [CopyFilesFromBuild]
 copy = cpanfile


### PR DESCRIPTION
This is a followup to #16.

The first commit reverts #16 to restore `#!/usr/bin/env perl` in `bin/mpath` instead of `#!perl` because this is more convenient for development as @paultcochrane requested.
The second one adds [a dzil plugin](https://metacpan.org/pod/Dist::Zilla::Plugin::SetScriptShebang) that will fix the shebang for the distribution.

So the final output for the distribution is exactly the same as since #16 has been applied, but the repo is easier to use for development.
